### PR TITLE
Adding output grids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ bin/
 cmake_install.cmake
 cmake_uninstall.cmake
 *.log
+install_manifest.txt
+lib/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+doc/examples/*/output/*
+CMakeCache.txt
+CMakeDoxyfile.in
+CMakeDoxygenDefaults.cmake
+CMakeFiles/
+CPackConfig.cmake
+CPackSourceConfig.cmake
+Makefile
+alpine3d/CMakeFiles/
+alpine3d/Makefile
+alpine3d/cmake_install.cmake
+bin/
+cmake_install.cmake
+cmake_uninstall.cmake
+*.log

--- a/alpine3d/MeteoObj.cc
+++ b/alpine3d/MeteoObj.cc
@@ -68,7 +68,6 @@ bool SnGrids::initStaticData()
 	paramname.push_back("ET");
   paramname.push_back("ISWR_TERRAIN");
   paramname.push_back("ILWR_TERRAIN");
-  paramname.push_back("VIEW_FACTOR");
   paramname.push_back("ISWR_BELOW_CAN");
 	paramname.push_back("TSOIL1");
 	paramname.push_back("TSOIL2");

--- a/alpine3d/MeteoObj.cc
+++ b/alpine3d/MeteoObj.cc
@@ -66,6 +66,9 @@ bool SnGrids::initStaticData()
 	paramname.push_back("GLACIER");
 	paramname.push_back("GLACIER_EXPOSED");
 	paramname.push_back("ET");
+  paramname.push_back("ISWR_TERRAIN");
+  paramname.push_back("ILWR_TERRAIN");
+  paramname.push_back("VIEW_FACTOR");
 	paramname.push_back("TSOIL1");
 	paramname.push_back("TSOIL2");
 	paramname.push_back("TSOIL3");

--- a/alpine3d/MeteoObj.cc
+++ b/alpine3d/MeteoObj.cc
@@ -69,6 +69,7 @@ bool SnGrids::initStaticData()
   paramname.push_back("ISWR_TERRAIN");
   paramname.push_back("ILWR_TERRAIN");
   paramname.push_back("VIEW_FACTOR");
+  paramname.push_back("ISWR_BELOW_CAN");
 	paramname.push_back("TSOIL1");
 	paramname.push_back("TSOIL2");
 	paramname.push_back("TSOIL3");

--- a/alpine3d/MeteoObj.h
+++ b/alpine3d/MeteoObj.h
@@ -67,6 +67,9 @@ class SnGrids {
                                           GLACIER, ///< mask showing the glaciated pixels
                                           GLACIER_EXPOSED, ///< mask showing the exposed glaciated pixels (ie not snow covered)
                                           ET, ///< Evapotranspiration
+                                          ISWR_TERRAIN, ///< Short wave received by terrain reflection
+                                          ILWR_TERRAIN, ///< Long wave received by terrain emission
+                                          VIEW_FACTOR, ///< Sky view factor
                                           TSOIL1, TSOIL2, TSOIL3, TSOIL4, TSOIL5, ///< Temperature within the soil, at a given depth
                                           lastparam=TSOIL5};
 

--- a/alpine3d/MeteoObj.h
+++ b/alpine3d/MeteoObj.h
@@ -69,7 +69,6 @@ class SnGrids {
                                           ET, ///< Evapotranspiration
                                           ISWR_TERRAIN, ///< Short wave received by terrain reflection
                                           ILWR_TERRAIN, ///< Long wave received by terrain emission
-                                          VIEW_FACTOR, ///< Sky view factor
                                           ISWR_BELOW_CAN,
                                           TSOIL1, TSOIL2, TSOIL3, TSOIL4, TSOIL5, ///< Temperature within the soil, at a given depth
                                           lastparam=TSOIL5};

--- a/alpine3d/MeteoObj.h
+++ b/alpine3d/MeteoObj.h
@@ -70,6 +70,7 @@ class SnGrids {
                                           ISWR_TERRAIN, ///< Short wave received by terrain reflection
                                           ILWR_TERRAIN, ///< Long wave received by terrain emission
                                           VIEW_FACTOR, ///< Sky view factor
+                                          ISWR_BELOW_CAN,
                                           TSOIL1, TSOIL2, TSOIL3, TSOIL4, TSOIL5, ///< Temperature within the soil, at a given depth
                                           lastparam=TSOIL5};
 

--- a/alpine3d/SnowpackInterface.cc
+++ b/alpine3d/SnowpackInterface.cc
@@ -128,10 +128,6 @@ SnowpackInterface::SnowpackInterface(const mio::Config& io_cfg, const size_t& nb
 	//create and prepare  the vector of output grids
 	if (grids_write) {
 		sn_cfg.getValue("GRIDS_PARAMETERS", "output", output_grids);
-    for(auto& o:output_grids)
-    {
-      std::cout << o << std::endl;
-    }
 		std::vector<double> soil_temp_depths;
 		sn_cfg.getValue("SOIL_TEMPERATURE_DEPTHS", "Output", soil_temp_depths, IOUtils::nothrow);
 		const unsigned short max_Tsoil( SnGrids::lastparam - SnGrids::TSOIL1 + 1 );
@@ -742,8 +738,6 @@ mio::Grid2DObject SnowpackInterface::getGrid(const SnGrids::Parameters& param) c
       return terrain_shortwave;
     case SnGrids::ILWR_TERRAIN:
       return terrain_longwave;
-    case SnGrids::VIEW_FACTOR:
-      return view_factor;
     case SnGrids::ISWR_DIFF:
 		  return diffuse;
 		case SnGrids::ISWR_DIR:

--- a/alpine3d/SnowpackInterface.cc
+++ b/alpine3d/SnowpackInterface.cc
@@ -133,6 +133,16 @@ SnowpackInterface::SnowpackInterface(const mio::Config& io_cfg, const size_t& nb
 	readInitalSnowCover(snow_stations,snow_stations_coord);
 
 	if (mpicontrol.master()) {
+
+    bool write_dem_details=false;
+    io_cfg.getValue("WRITE_DEM_DETAILS", "output", write_dem_details,IOUtils::nothrow);
+    if(write_dem_details){
+      std::cout << "[i] Writing DEM details grids" << std::endl;
+      io.write2DGrid(mio::Grid2DObject(dem.cellsize,dem.llcorner,dem.slope), "DEM_SLOPE");
+      io.write2DGrid(mio::Grid2DObject(dem.cellsize,dem.llcorner,dem.azi), "DEM_AZI");
+      io.write2DGrid(mio::Grid2DObject(dem.cellsize,dem.llcorner,dem.curvature), "DEM_CURVATURE");
+    }
+
 		std::cout << "[i] SnowpackInterface initializing a total of " << mpicontrol.size();
 		if (mpicontrol.size()>1) std::cout << " processes with " << nbworkers;
 		else std::cout << " process with " << nbworkers;

--- a/alpine3d/SnowpackInterface.cc
+++ b/alpine3d/SnowpackInterface.cc
@@ -744,6 +744,10 @@ mio::Grid2DObject SnowpackInterface::getGrid(const SnGrids::Parameters& param) c
       return terrain_longwave;
     case SnGrids::VIEW_FACTOR:
       return view_factor;
+    case SnGrids::ISWR_DIFF:
+		  return diffuse;
+		case SnGrids::ISWR_DIR:
+			return shortwave-diffuse-terrain_shortwave;
 		default: ; //so compilers do not complain about missing conditions
 	}
 

--- a/alpine3d/SnowpackInterface.cc
+++ b/alpine3d/SnowpackInterface.cc
@@ -26,6 +26,22 @@
 using namespace std;
 using namespace mio;
 
+const std::vector<std::string> SnowpackInterface::grids_not_computed_in_worker{
+"TA",
+"RH",
+"VW",
+"DW",
+"PSUM",
+"PSUM_PH",
+"PSUM_TECH",
+"MNS",
+"ISWR",
+"ILWR",
+"ISWR_TERRAIN",
+"ILWR_TERRAIN",
+"ISWR_DIFF",
+"ISWR_DIR"};
+
 //sort the by increasing y and increasing x as a second key
 inline bool pair_comparator(const std::pair<double, double>& l, const std::pair<double, double>& r)
 {
@@ -199,7 +215,9 @@ SnowpackInterface::SnowpackInterface(const mio::Config& io_cfg, const size_t& nb
 		OMPControl::getArraySliceParams(mpi_nx, nbworkers, ii, omp_offset, omp_nx);
 		const size_t offset = mpi_offset + omp_offset;
 
-		workers[ii] = new SnowpackInterfaceWorker(sn_cfg, sub_dem, sub_landuse, sub_pts, thread_stations, thread_stations_coord, offset);
+		workers[ii] = new SnowpackInterfaceWorker(sn_cfg, sub_dem, sub_landuse, sub_pts,
+                                              thread_stations, thread_stations_coord,
+                                              offset, grids_not_computed_in_worker);
 
 		worker_startx[ii] = offset;
 		worker_deltax[ii] = omp_nx;

--- a/alpine3d/SnowpackInterface.cc
+++ b/alpine3d/SnowpackInterface.cc
@@ -684,6 +684,8 @@ void SnowpackInterface::setMeteo(const Grid2DObject& new_psum, const Grid2DObjec
  */
 void SnowpackInterface::setRadiationComponents(const mio::Array2D<double>& shortwave_in,
      const mio::Array2D<double>& longwave_in, const mio::Array2D<double>& diff_in,
+     const mio::Array2D<double>& view_factor_in, const mio::Array2D<double>& terrain_shortwave_in,
+     const mio::Array2D<double>& terrain_longwave_in,
      const double& solarElevation_in, const mio::Date& timestamp)
 {
 	if (nextStepTimestamp != timestamp) {
@@ -697,6 +699,10 @@ void SnowpackInterface::setRadiationComponents(const mio::Array2D<double>& short
 	shortwave.grid2D = shortwave_in;
 	longwave.grid2D = longwave_in;
 	diffuse.grid2D = diff_in;
+  view_factor.grid2D = view_factor_in;
+  terrain_shortwave.grid2D = terrain_shortwave_in;
+  terrain_longwave.grid2D = terrain_longwave_in;
+
 	solarElevation = solarElevation_in;
 
 	dataRadiation = true;
@@ -735,9 +741,9 @@ mio::Grid2DObject SnowpackInterface::getGrid(const SnGrids::Parameters& param) c
     case SnGrids::ISWR_TERRAIN:
       return terrain_shortwave;
     case SnGrids::ILWR_TERRAIN:
-      return terrain_shortwave;
-    case SnGrids::VIEW_FACTOR:
       return terrain_longwave;
+    case SnGrids::VIEW_FACTOR:
+      return view_factor;
 		default: ; //so compilers do not complain about missing conditions
 	}
 

--- a/alpine3d/SnowpackInterface.h
+++ b/alpine3d/SnowpackInterface.h
@@ -159,6 +159,9 @@ class Runoff; // forward declaration, cyclic header include
 		void setRadiationComponents(const mio::Array2D<double>& shortw,
 		                            const mio::Array2D<double>& longwave,
 		                            const mio::Array2D<double>& diff,
+                                const mio::Array2D<double>& view_factor_in,
+                                const mio::Array2D<double>& terrain_shortwave_in,
+                                const mio::Array2D<double>& terrain_longwave_in,
 		                            const double& solarElevation,
 		                            const mio::Date& timestamp);
 

--- a/alpine3d/SnowpackInterface.h
+++ b/alpine3d/SnowpackInterface.h
@@ -130,7 +130,8 @@ class Runoff; // forward declaration, cyclic header include
 		// Methods for accessing Snopack Interface Manager
 		SnowpackInterface(const mio::Config &io_cfg, const size_t& nbworkers,
 		                  const mio::DEMObject& dem_in,
-		                  const mio::Grid2DObject& landuse_in, const std::vector<mio::Coords>& vec_pts, const mio::Date& startTime, const std::string& grids_requirements, const bool is_restart_in);
+		                  const mio::Grid2DObject& landuse_in, const std::vector<mio::Coords>& vec_pts,
+                      const mio::Date& startTime, const std::string& grids_requirements, const bool is_restart_in);
 		SnowpackInterface(const SnowpackInterface&);
 		~SnowpackInterface();
 
@@ -168,6 +169,7 @@ class Runoff; // forward declaration, cyclic header include
 		mio::Grid2DObject getGrid(const SnGrids::Parameters& param) const;
 
 	private:
+    static const std::vector<std::string> grids_not_computed_in_worker;
 		std::string getGridsRequirements() const;
 		mio::Config readAndTweakConfig(const mio::Config& io_cfg,const bool have_pts);
 		bool do_grid_output(const mio::Date &date) const;

--- a/alpine3d/SnowpackInterface.h
+++ b/alpine3d/SnowpackInterface.h
@@ -219,7 +219,7 @@ class Runoff; // forward declaration, cyclic header include
 		size_t mpi_offset, mpi_nx;
 		mio::Grid2DObject landuse;
 		// meteo forcing variables
-		mio::Grid2DObject mns, shortwave, longwave, diffuse;
+		mio::Grid2DObject mns, shortwave, longwave, diffuse, view_factor, terrain_shortwave, terrain_longwave;
 		mio::Grid2DObject psum, psum_ph, psum_tech, grooming, vw, dw, rh, ta, init_glaciers_height;
 		double solarElevation;
 

--- a/alpine3d/SnowpackInterfaceWorker.cc
+++ b/alpine3d/SnowpackInterfaceWorker.cc
@@ -324,10 +324,8 @@ void SnowpackInterfaceWorker::fillGrids(const size_t& ii, const size_t& jj, cons
 				value = meteoPixel.dw; break;
 			case SnGrids::ISWR:
 				value = meteoPixel.iswr; break;
-			case SnGrids::ISWR_DIFF:
-				value = (useEBalance)? meteoPixel.diff : IOUtils::nodata; break;
-			case SnGrids::ISWR_DIR:
-				value = (useEBalance)? meteoPixel.iswr - meteoPixel.diff : IOUtils::nodata; break;
+			case SnGrids::ISWR_BELOW_CAN:
+				value = (useEBalance)? meteoPixel.iswr : IOUtils::nodata; break;
 			case SnGrids::ILWR:
 				value = Atmosphere::blkBody_Radiation(meteoPixel.ea, meteoPixel.ta); break;
 			case SnGrids::HS:
@@ -400,6 +398,8 @@ void SnowpackInterfaceWorker::fillGrids(const size_t& ii, const size_t& jj, cons
       case SnGrids::ISWR_TERRAIN:
       case SnGrids::ILWR_TERRAIN:
       case SnGrids::VIEW_FACTOR:
+      case SnGrids::ISWR_DIR:
+      case SnGrids::ISWR_DIFF:
           break;
 			default:
 				if (it->first>=SnGrids::TSOIL1 && it->first<=SnGrids::lastparam) //dealing with soil temperatures
@@ -408,6 +408,7 @@ void SnowpackInterfaceWorker::fillGrids(const size_t& ii, const size_t& jj, cons
 				}
 				else
 				{
+          std::cout << it->first << std::endl;
 					throw InvalidArgumentException("Invalid parameter requested", AT);
 				}
 		}

--- a/alpine3d/SnowpackInterfaceWorker.cc
+++ b/alpine3d/SnowpackInterfaceWorker.cc
@@ -397,7 +397,6 @@ void SnowpackInterfaceWorker::fillGrids(const size_t& ii, const size_t& jj, cons
 					break;
       case SnGrids::ISWR_TERRAIN:
       case SnGrids::ILWR_TERRAIN:
-      case SnGrids::VIEW_FACTOR:
       case SnGrids::ISWR_DIR:
       case SnGrids::ISWR_DIFF:
           break;

--- a/alpine3d/SnowpackInterfaceWorker.cc
+++ b/alpine3d/SnowpackInterfaceWorker.cc
@@ -224,7 +224,6 @@ void SnowpackInterfaceWorker::initGrids(std::vector<std::string>& params,
                          grids_not_computed_in_worker.end(),
                          params[ii]);
     if(position<grids_not_computed_in_worker.end()) {
-      std::cout << "XXX parameter " << params[ii] << " ignored" << std::endl;
       continue;
     }
 		if (param_idx==IOUtils::npos)

--- a/alpine3d/SnowpackInterfaceWorker.cc
+++ b/alpine3d/SnowpackInterfaceWorker.cc
@@ -397,6 +397,10 @@ void SnowpackInterfaceWorker::fillGrids(const size_t& ii, const size_t& jj, cons
 					// Add part from Canopy
 					value += useCanopy?(snowPixel.Cdata.transp+snowPixel.Cdata.intevap)/snowPixel.cos_sl:0; //slope2horiz
 					break;
+      case SnGrids::ISWR_TERRAIN:
+      case SnGrids::ILWR_TERRAIN:
+      case SnGrids::VIEW_FACTOR:
+          break;
 			default:
 				if (it->first>=SnGrids::TSOIL1 && it->first<=SnGrids::lastparam) //dealing with soil temperatures
 				{

--- a/alpine3d/SnowpackInterfaceWorker.h
+++ b/alpine3d/SnowpackInterfaceWorker.h
@@ -32,7 +32,8 @@ class SnowpackInterfaceWorker
 		                        const std::vector< std::pair<size_t,size_t> >& pts_in,
 		                        const std::vector<SnowStation*>& snow_stations,
 		                        const std::vector<std::pair<size_t,size_t> >& snow_stations_coord,
-		                        const size_t offset_in);
+		                        const size_t offset_in,
+                            const std::vector<std::string>& grids_not_computed_in_worker);
 
 		~SnowpackInterfaceWorker();
 
@@ -44,7 +45,6 @@ class SnowpackInterfaceWorker
 		void clearSpecialPointsData();
 
 		mio::Grid2DObject getGrid(const SnGrids::Parameters& param) const;
-		double& getGridPoint(const SnGrids::Parameters& param, const size_t& ii, const size_t& jj);
 
 		void runModel(const mio::Date& julian,
 		              const mio::Grid2DObject &psum,
@@ -70,9 +70,10 @@ class SnowpackInterfaceWorker
 		void setLateralFlow(const std::vector<SnowStation*>& snow_station);
 
 	private:
-		void initGrids(std::vector<std::string>& params);
+		void initGrids(std::vector<std::string>& params, const std::vector<std::string>& grids_not_computed_in_worker);
 		void gatherSpecialPoints(const CurrentMeteo& meteoPixel, const SnowStation& snowPixel, const SurfaceFluxes& surfaceFlux);
 		void fillGrids(const size_t& ii, const size_t& jj, const CurrentMeteo& meteoPixel, const SnowStation& snowPixel, const SurfaceFluxes& surfaceFlux);
+    double& getGridPoint(const SnGrids::Parameters& param, const size_t& ii, const size_t& jj);
 
 	private:
 		SnowpackConfig sn_cfg; // created on element

--- a/alpine3d/ebalance/TerrainRadiation.cc
+++ b/alpine3d/ebalance/TerrainRadiation.cc
@@ -81,7 +81,9 @@ TerrainRadiation::TerrainRadiation(const mio::Config& cfg, const mio::DEMObject&
 	viewFactorsObj.generate();
 }
 
-void TerrainRadiation::getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal)
+void TerrainRadiation::getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse,
+                                    mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal,
+                                    mio::Array2D<double>& view_factor)
 {
 	if (MPIControl::instance().master())
 		printf("[i] Calculating terrain radiation with standard method\n");

--- a/alpine3d/ebalance/TerrainRadiation.h
+++ b/alpine3d/ebalance/TerrainRadiation.h
@@ -48,7 +48,9 @@ class TerrainRadiation : public TerrainRadiationAlgorithm {
 	public:
 		TerrainRadiation(const mio::Config& i_cfg, const mio::DEMObject &dem_in, const int& i_nbworkers, const std::string& method);
 
-		void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal);
+		void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse,
+                      mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal,
+                      mio::Array2D<double>& view_factor);
 		void setMeteo(const mio::Array2D<double>& albedo, const mio::Array2D<double>& ta,
 		              const mio::Array2D<double>& rh, const mio::Array2D<double>& ilwr);
 

--- a/alpine3d/ebalance/TerrainRadiationAlgorithm.cc
+++ b/alpine3d/ebalance/TerrainRadiationAlgorithm.cc
@@ -38,7 +38,7 @@ TerrainRadiationAlgorithm* TerrainRadiationFactory::getAlgorithm(const Config& c
 	IOUtils::toUpper(method);
 
 	if (method == "SIMPLE") {
-		return new TerrainRadiationSimple(dem, method);
+		return new TerrainRadiationSimple(cfg, dem, method);
 	} else if (method == "HELBIG") {
 		return new TerrainRadiationHelbig(cfg, dem, nbworkers, method);
 	} else if (method == "COMPLEX") {

--- a/alpine3d/ebalance/TerrainRadiationAlgorithm.h
+++ b/alpine3d/ebalance/TerrainRadiationAlgorithm.h
@@ -39,7 +39,9 @@ class TerrainRadiationAlgorithm {
 		TerrainRadiationAlgorithm(const std::string& i_algo) : algo(i_algo) {}
 		virtual ~TerrainRadiationAlgorithm();
 		// FELIX: mio::Array2D<double>& direct_unshaded_horizontal
-		virtual void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal) = 0;
+		virtual void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse,
+                              mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal,
+                              mio::Array2D<double>& view_factor) = 0;
 		virtual void setMeteo(const mio::Array2D<double>& albedo, const mio::Array2D<double>& ta,
 		                      const mio::Array2D<double>& rh, const mio::Array2D<double>& ilwr) = 0;
 		const std::string algo;

--- a/alpine3d/ebalance/TerrainRadiationComplex.cc
+++ b/alpine3d/ebalance/TerrainRadiationComplex.cc
@@ -70,7 +70,19 @@ TerrainRadiationComplex::TerrainRadiationComplex(const mio::Config& cfg_in, cons
 	initSortList();
   initSkyViewFactor();
 	if (if_write_view_list) WriteViewList();									// Write ViewList to file
-	if (cfg.keyExists("PVPFILE", "EBalance")) PVobject->initTerrain(M_epsilon, M_phi);	// Link SolarPanel-object to ViewList
+
+	if (cfg_in.keyExists("PVPFILE", "EBalance")) PVobject->initTerrain(M_epsilon, M_phi);	// Link SolarPanel-object to ViewList
+
+  bool write_sky_vf=false;
+  cfg.getValue("WRITE_SKY_VIEW_FACTOR", "output", write_sky_vf,IOUtils::nothrow);
+
+  if(MPIControl::instance().master() && write_sky_vf){
+    std::cout << "[i] Writing sky view factor grid" << std::endl;
+    mio::Array2D<double> sky_vf(dimx,dimy);
+    getSkyViewFactor(sky_vf);
+    mio::IOManager io(cfg_in);
+    io.write2DGrid(mio::Grid2DObject(dem_in.cellsize,dem_in.llcorner,sky_vf), "SKY_VIEW_FACTOR");
+  }
 
 }
 

--- a/alpine3d/ebalance/TerrainRadiationComplex.cc
+++ b/alpine3d/ebalance/TerrainRadiationComplex.cc
@@ -18,15 +18,16 @@
 #include <alpine3d/ebalance/TerrainRadiationComplex.h>
 
 //file operations
-#include <iostream> 
-#include <fstream> 
+#include <iostream>
+#include <fstream>
 
 using namespace mio;
 
 
 TerrainRadiationComplex::TerrainRadiationComplex(const mio::Config& cfg_in, const mio::DEMObject& dem_in, const std::string& method, const RadiationField* radfield, SolarPanel* PVobject_in)
-                      : TerrainRadiationAlgorithm(method), dimx(dem_in.getNx()), dimy(dem_in.getNy()), dem(dem_in), cfg(cfg_in), BRDFobject(cfg_in), 
-                      radobject(radfield), PVobject(PVobject_in), albedo_grid(dem_in.getNx(), dem_in.getNy(), IOUtils::nodata)
+                      : TerrainRadiationAlgorithm(method), dimx(dem_in.getNx()), dimy(dem_in.getNy()), dem(dem_in), cfg(cfg_in), BRDFobject(cfg_in),
+                      radobject(radfield), PVobject(PVobject_in), albedo_grid(dem_in.getNx(), dem_in.getNy(), IOUtils::nodata),
+                      sky_vf(2, mio::Array2D<double>(dimx, dimy, IOUtils::nodata)), sky_vf_mean(dimx, dimy, IOUtils::nodata)
 {
 	// PRECISION PARAMETERS
 	// ####################
@@ -54,7 +55,7 @@ TerrainRadiationComplex::TerrainRadiationComplex(const mio::Config& cfg_in, cons
 		succesful_read=ReadViewList();
 		initBasicSetHorizontal();
 		initBasicSetRotated();
-	} 
+	}
 
 	// Initialise from scratch
 	if (!succesful_read){
@@ -67,10 +68,10 @@ TerrainRadiationComplex::TerrainRadiationComplex(const mio::Config& cfg_in, cons
 	// Initialise Speed-up
 	initRList();
 	initSortList();
-
+  initSkyViewFactor();
 	if (if_write_view_list) WriteViewList();									// Write ViewList to file
 	if (cfg.keyExists("PVPFILE", "EBalance")) PVobject->initTerrain(M_epsilon, M_phi);	// Link SolarPanel-object to ViewList
-	
+
 }
 
 TerrainRadiationComplex::~TerrainRadiationComplex() {}
@@ -83,11 +84,11 @@ TerrainRadiationComplex::~TerrainRadiationComplex() {}
 /**
 * @brief Initializes set of Vectors that point to equal solid angels for horizontal hemisphere (BasicSet) [MT 2.1.1 Basic Set]
 * @param[in] -
-* @param[out] - 
-* 
+* @param[out] -
+*
 */
 void TerrainRadiationComplex::initBasicSetHorizontal(){
-	
+
 	double psi_0=0,psi_1=0,epsilon=0;
 	double delta=0;
 	double phi=0;
@@ -121,7 +122,7 @@ void TerrainRadiationComplex::initBasicSetHorizontal(){
 /**
 * @brief Rotates BasicSet in Plane of triangular Surface Object		[MT 2.1.3 View-List]
 * @param[in] -
-* @param[out] - 
+* @param[out] -
 *
 */
 void TerrainRadiationComplex::initBasicSetRotated(){
@@ -155,10 +156,10 @@ void TerrainRadiationComplex::initBasicSetRotated(){
 /**
 * @brief Assigns a pixel (or sky) to each space vector of each ProjectVectorToPlane		[MT 2.1.2 Surface Generation and 2.1.3 View-List]
 * @param[in] -
-* @param[out] - 
-*	
+* @param[out] -
+*
 */
-void TerrainRadiationComplex::initViewList(){	
+void TerrainRadiationComplex::initViewList(){
 
 	std::cout<<"[i] Initialize Terrain Radiation Complex\n";
 
@@ -184,9 +185,9 @@ void TerrainRadiationComplex::initViewList(){
 			 		size_t which_triangle_temp=9;
 				 	double distance, minimal_distance=dem.cellsize*(dem.getNx()+dem.getNy());
 
-				 	// Search for Intersection Candidates 
+				 	// Search for Intersection Candidates
 				 	size_t ii_dem=ii, jj_dem=jj, nb_cells=0;
-			 		std::vector<double> ray=BasicSet_rotated(ii,jj, which_triangle,solidangle); 
+			 		std::vector<double> ray=BasicSet_rotated(ii,jj, which_triangle,solidangle);
 		 			std::vector<double> projected_ray=ProjectVectorToPlane(ray, {0,0,1});					// [in MT 2.1.3:  projected_ray ~ v_view,yx]
 		 			if (NormOfVector(projected_ray) != 0 ) projected_ray=normalizeVector(projected_ray);
 					else projected_ray={1,0,0}; // if it goes straight up there will be sky (no caves for 2D DEM)
@@ -197,14 +198,14 @@ void TerrainRadiationComplex::initViewList(){
 						for (int k = -1; k < 2; ++k)
 						{
 							for (int kk = -1; kk < 2; ++kk)
-							{	
+							{
 
 								ii_dem = ii + (int)round( ((double)nb_cells)*projected_ray[0] ) + k;		// [~ MT eq. 2.32]
 								jj_dem = jj + (int)round( ((double)nb_cells)*projected_ray[1] ) + kk;		// [~ MT eq. 2.32]
 								if((ii_dem<1 || ii_dem>dem.getNx()-2 || jj_dem<1 || jj_dem>dem.getNy()-2)) continue;
 
-								distance=IntersectionRayTriangle(ray,ii,jj,ii_dem,jj_dem,0); // Triangles B: [MT Figure 2.2] 
-								if (distance!=-999 && distance<minimal_distance) 
+								distance=IntersectionRayTriangle(ray,ii,jj,ii_dem,jj_dem,0); // Triangles B: [MT Figure 2.2]
+								if (distance!=-999 && distance<minimal_distance)
 								{
 									minimal_distance=distance; // If intersection with sevaral trangles, take the closest intersection
 									ii_temp=ii_dem;
@@ -212,7 +213,7 @@ void TerrainRadiationComplex::initViewList(){
 									which_triangle_temp=0;
 								}
 
-								distance=IntersectionRayTriangle(ray,ii,jj,ii_dem,jj_dem,1); // Triangles A: [MT Figure 2.2] 
+								distance=IntersectionRayTriangle(ray,ii,jj,ii_dem,jj_dem,1); // Triangles A: [MT Figure 2.2]
 								if (distance!=-999 && distance<minimal_distance)
 								{
 									minimal_distance=distance; // If intersection with sevaral trangles, take the closest intersection
@@ -230,27 +231,27 @@ void TerrainRadiationComplex::initViewList(){
 
 					}
 					if (minimal_distance==dem.cellsize*(dem.getNx()+dem.getNy())) minimal_distance=-999; // No intersection found    =>    -999 == "SKY"
-					if (ii_temp>0 && ii_temp<dimx) solidangle_temp=vectorToSPixel(VectorStretch(ray,-1), ii_temp, jj_temp, which_triangle_temp); 
+					if (ii_temp>0 && ii_temp<dimx) solidangle_temp=vectorToSPixel(VectorStretch(ray,-1), ii_temp, jj_temp, which_triangle_temp);
 					ViewList(ii, jj, which_triangle, solidangle)={(double)ii_temp, (double)jj_temp, (double)which_triangle_temp, minimal_distance, (double)solidangle_temp}; // [MT eq. 2.47]
 				}
 				counter++;
 				if (counter%10==0) PrintProgress((double)counter/(double)(dimx-2)/(double)(dimy-2)/2.);
-				
+
 			}
 		}
 	}
 	PrintProgress(1);
 	std::cout<<"  Done.\n";
-	
-	
+
+
 }
 
 
 /**
-* @brief +SPEEDUP+ Projects BRDF on Basic Set. Instead of Calculating/Intrapolating all the time 
+* @brief +SPEEDUP+ Projects BRDF on Basic Set. Instead of Calculating/Intrapolating all the time
 * 					new BRDF factors, store discrete number covering whole hemisphere
 * @param[in] -
-* @param[out] - 
+* @param[out] -
 *
 */
 void TerrainRadiationComplex::initRList(){
@@ -273,16 +274,16 @@ void TerrainRadiationComplex::initRList(){
 
 			RList(number_solid_in, number_solid_out)=BRDFobject.get_RF(cth_i, cphi, cth_v);
 		}
-	}	
+	}
 }
 
 
 
 /**
-* @brief +SPEEDUP+: For most terrain a large part of the basicSet points in the sky. SortList Stores land-pointing vectors only. 
+* @brief +SPEEDUP+: For most terrain a large part of the basicSet points in the sky. SortList Stores land-pointing vectors only.
 * Only these need a iterative radiation computation. [not discussed in MT and somewhat confusing syntax in MT eq. 2.95, sorry. Better Look @ Paper ????]
 * @param[in] -
-* @param[out] - 
+* @param[out] -
 *
 */
 void TerrainRadiationComplex::initSortList(){
@@ -298,7 +299,7 @@ void TerrainRadiationComplex::initSortList(){
 			{
 				for (size_t solidangle = 0; solidangle < S; ++solidangle)
 				{
-					
+
 					double distance=ViewList(ii,jj,which_triangle, solidangle)[3];
 					if (distance==-999) continue;
 
@@ -322,7 +323,7 @@ void TerrainRadiationComplex::initSortList(){
 			for (size_t which_triangle = 0; which_triangle < 2; ++which_triangle) // Triangles: A=1, B=0  [MT Figure 2.2]
 			{
 				sort( SortList(ii, jj, which_triangle).begin(), SortList(ii, jj, which_triangle).end() );
-				SortList(ii, jj, which_triangle).erase( unique( SortList(ii, jj, which_triangle).begin(), SortList(ii, jj, which_triangle).end() ), SortList(ii, jj, which_triangle).end() ); 
+				SortList(ii, jj, which_triangle).erase( unique( SortList(ii, jj, which_triangle).begin(), SortList(ii, jj, which_triangle).end() ), SortList(ii, jj, which_triangle).end() );
 			}
 		}
 	}
@@ -331,7 +332,7 @@ void TerrainRadiationComplex::initSortList(){
 /**
 * @brief Writes Viewlist to file, use SMET format only
 * @param[in] -
-* @param[out] - 
+* @param[out] -
 *
 */
 void TerrainRadiationComplex::WriteViewList()
@@ -384,7 +385,7 @@ void TerrainRadiationComplex::WriteViewList()
 /**
 * @brief Reads ViewList from file, use SMET format only
 * @param[in] -
-* @param[out] - 
+* @param[out] -
 *
 */
 bool TerrainRadiationComplex::ReadViewList()
@@ -395,7 +396,7 @@ bool TerrainRadiationComplex::ReadViewList()
 		throw NotFoundException(filename, AT);
 		return false;
 	}
-	
+
 	smet::SMETReader myreader(filename);
 	std::vector<double> vec_data;
 	myreader.read(vec_data);
@@ -455,7 +456,7 @@ bool TerrainRadiationComplex::ReadViewList()
 	for (size_t ii=0; ii<vec_data.size(); ii+=nr_fields) {
 
 		ViewList(vec_data[ii+ii_fd], vec_data[ii+jj_fd], vec_data[ii+which_triangle_fd], vec_data[ii+solidangle_fd])={(double)vec_data[ii+ii_seen_fd], (double)vec_data[ii+jj_seen_fd], (double)vec_data[ii+which_triangle_seen_fd], vec_data[ii+distance_fd], (double)vec_data[ii+soldiangle_seen_fd]};
-			
+
 	}
 
 	std::cout<<"[i] TerrainRadiationComplex: Initialized "<<M_epsilon<<"x"<<M_phi<<" ViewList from file\n";
@@ -470,17 +471,18 @@ bool TerrainRadiationComplex::ReadViewList()
 
 
 /**
-* @brief Computes direct, diffuse and terrain radiation for each gridpoint. Terrain radiation 
+* @brief Computes direct, diffuse and terrain radiation for each gridpoint. Terrain radiation
 * @param[in] -
-* @param[out] - 
+* @param[out] -
 *
 */
-void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal)
+void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain,
+                                            mio::Array2D<double>& direct_unshaded_horizontal,mio::Array2D<double>& view_factor)
 {
 
 	// Special T_Lists for Radation analysis
 	mio::Array4D<double> TList_ms_old(dimx, dimy, 2, S, 0), TList_ms_new(dimx, dimy, 2, S, 0); 	// Total reflected radiance (W/m2/sr)  for all Vectors of basic set and all triangles of DEM
-	mio::Array4D<double> TList_sky_aniso(dimx, dimy, 2, S, 0); 									// Anisotropic single-scattered radiance from sun&sky (W/m2/sr) 
+	mio::Array4D<double> TList_sky_aniso(dimx, dimy, 2, S, 0); 									// Anisotropic single-scattered radiance from sun&sky (W/m2/sr)
 	mio::Array4D<double> TList_sky_iso(dimx, dimy, 2, S, 0);									// Isotropic single-scattered radiance from sun&sky (W/m2/sr)
 	mio::Array4D<double> TList_direct(dimx, dimy, 2, S, 0);										// Anisotropic single-scattered radiance only from direct solar (W/m2/sr), (used in SolarPanel-module for shadow)
 
@@ -504,7 +506,7 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 		for (size_t jj = 1; jj < dimy-1; ++jj)
 		{
 			//////////////////////////////////
-			///// DIRECT [in MT eq. 2.96: F_direct,t] 
+			///// DIRECT [in MT eq. 2.96: F_direct,t]
 			size_t solidangle_sun;
 			double distance_closest_triangle;
 
@@ -564,7 +566,7 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 
 
 
-			
+
 			for (size_t which_triangle = 0; which_triangle < 2; ++which_triangle) // Triangles: A=1, B=0  [MT Figure 2.2]
 			{
 				if (v_sun[2]<0) continue;  // might be to strict for Dawn..
@@ -577,7 +579,7 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 					diffuse_t = skydiffuse_B(ii,jj);
 					direct_t = direct_B(ii,jj);
 				}
- 
+
 
 
 				if (VectorScalarProduct(TriangleNormal(ii,jj,which_triangle),v_sun)>0)  solidangle_sun=vectorToSPixel(v_sun, ii, jj, which_triangle);
@@ -589,7 +591,7 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 					{
 						TList_sky_aniso(ii,jj,which_triangle, solidangle_out)=(direct_t+diffuse_t)*albedo_temp/Cst::PI;
 						TList_sky_iso(ii,jj,which_triangle, solidangle_out)=TList_sky_aniso(ii,jj,which_triangle, solidangle_out);
-						TList_direct(ii,jj,which_triangle, solidangle_out)=(direct_t)*albedo_temp/Cst::PI;						
+						TList_direct(ii,jj,which_triangle, solidangle_out)=(direct_t)*albedo_temp/Cst::PI;
 					}
 				}
 				else{
@@ -597,7 +599,7 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 					{
 						TList_sky_aniso(ii,jj,which_triangle, solidangle_out)=(RList(solidangle_sun, solidangle_out)*direct_t+diffuse_t)*albedo_temp/Cst::PI;
 						TList_sky_iso(ii,jj,which_triangle, solidangle_out)=(direct_t+diffuse_t)*albedo_temp/Cst::PI;
-						TList_direct(ii,jj,which_triangle, solidangle_out)=(RList(solidangle_sun, solidangle_out)*direct_t)*albedo_temp/Cst::PI;					
+						TList_direct(ii,jj,which_triangle, solidangle_out)=(RList(solidangle_sun, solidangle_out)*direct_t)*albedo_temp/Cst::PI;
 					}
 				}
 			}
@@ -617,7 +619,7 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 
 		TList_ms_old=TList_ms_new+TList_sky_aniso;
 		terrain_flux_old=terrain_flux_new;
-		
+
 
 		TList_ms_new.resize(dimx, dimy, 2, S, 0.);
 		terrain_flux_new.resize(dimx, dimy,2, 0.);
@@ -630,7 +632,7 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 				double albedo_temp=albedo_grid(ii,jj);
 
 				for (size_t which_triangle = 0; which_triangle < 2; ++which_triangle) // Triangles: A=1, B=0  [MT Figure 2.2]
-				{	
+				{
 					for (size_t solidangle_in = 0; solidangle_in < S; ++solidangle_in)
 					{
 						double Rad_solidangle;
@@ -648,7 +650,7 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 
 
 						Rad_solidangle=Rad_solidangle*albedo_temp/S;
-						
+
 						size_t solidangle_out=0;
 						// These are the most expensive loops... core of [MT eq. 2.97]
 						if (albedo_temp<0.5 || !if_anisotropy){
@@ -662,14 +664,14 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 							for (size_t kk = 0; kk < SortList(ii,jj,which_triangle).size(); ++kk)
 							{
 								solidangle_out=SortList(ii,jj,which_triangle)[kk];
-								TList_ms_new(ii,jj,which_triangle, solidangle_out)+=Rad_solidangle*RList(solidangle_in, solidangle_out);		
+								TList_ms_new(ii,jj,which_triangle, solidangle_out)+=Rad_solidangle*RList(solidangle_in, solidangle_out);
 							}
 						}
 					}
 				}
 			}
 		}
-		
+
 		// Test if convergence is below treshold [MT eq. 2.100]
 		if (number_rounds!=0 && TerrainBiggestDifference(terrain_flux_new, terrain_flux_old)<delta_F_max) another_round=0;
 		++number_rounds;
@@ -683,7 +685,7 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 	{
 		TList_ms_old=TList_ms_new+TList_sky_aniso;
 		terrain_flux_old=terrain_flux_new;
-			
+
 		TList_ms_new.resize(dimx, dimy, 2, S, 0.);
 		terrain_flux_new.resize(dimx, dimy,2, 0.);
 
@@ -695,7 +697,7 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 				double albedo_temp=albedo_grid(ii,jj);
 
 				for (size_t which_triangle = 0; which_triangle < 2; ++which_triangle) // Triangles: A=1, B=0  [MT Figure 2.2]
-				{	
+				{
 					for (size_t solidangle_in = 0; solidangle_in < S; ++solidangle_in)
 					{
 						double Rad_solidangle;
@@ -712,7 +714,7 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 						terrain_flux_new(ii, jj, which_triangle)+=Rad_solidangle/S*Cst::PI;
 
 						Rad_solidangle=Rad_solidangle*albedo_temp/S;
-							
+
 						if(!cfg.keyExists("PVPFILE", "EBalance")) continue;
 
 						if (albedo_temp<0.5 || !if_anisotropy){
@@ -724,13 +726,13 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 						else{
 							for (size_t solidangle_out = 0; solidangle_out < S; ++solidangle_out)
 							{
-								TList_ms_new(ii,jj,which_triangle, solidangle_out)+=Rad_solidangle*RList(solidangle_in, solidangle_out);			
+								TList_ms_new(ii,jj,which_triangle, solidangle_out)+=Rad_solidangle*RList(solidangle_in, solidangle_out);
 							}
 						}
 					}
 				}
 			}
-		}			
+		}
 	}
 
 	// If SolarPanel-module is used, send all needed data
@@ -748,6 +750,7 @@ void TerrainRadiationComplex::getRadiation(const mio::Array2D<double>& direct, m
 
 	diffuse=diffuse_temp;
 	terrain=terrain_temp;
+  getSkyViewFactor(view_factor);
 
 	std::cout<<"[i] TerrainRadiationComplex converged in "<<number_rounds+1<<" Full Iteration(s).\n";
 }
@@ -767,8 +770,8 @@ void TerrainRadiationComplex::setMeteo(const mio::Array2D<double>& albedo, const
 * @brief returns normalized surface-normal vector [MT 2.1.2 Surface Generation]
 * @param[in] ii_dem: easting DEM-Grid-Point
 * @param[in] jj_dem: northing DEM-Grid-Point
-* @param[in] which_triangle: 1 or 2 
-* @param[out] {n_x,n_y,n_z} 
+* @param[in] which_triangle: 1 or 2
+* @param[out] {n_x,n_y,n_z}
 */
 std::vector<double> TerrainRadiationComplex::TriangleNormal(size_t ii_dem, size_t jj_dem, int which_triangle)
 {
@@ -776,7 +779,7 @@ std::vector<double> TerrainRadiationComplex::TriangleNormal(size_t ii_dem, size_
 	double cellsize=dem.cellsize;
 
 	// Triangles: A=1, B=0  [MT Figure 2.2]
-	if (which_triangle==1) 
+	if (which_triangle==1)
 	{
 		e_x={-cellsize,0, dem(ii_dem-1,jj_dem)-dem(ii_dem,jj_dem)};	//[MT eq. 2.17]
 		e_y={0,cellsize, dem(ii_dem,jj_dem+1)-dem(ii_dem,jj_dem)}; 	//[MT eq. 2.18]
@@ -798,13 +801,13 @@ std::vector<double> TerrainRadiationComplex::TriangleNormal(size_t ii_dem, size_
 * @param[in] v_view: see [MT fig. 2.3]
 * @param[in] nn, mm: origin of v_view. Why not specification of which_triangle in nn,mm? Because have identical base point (DEM-Grid_point) [MT Figure 2.2]
 * @param[in] ii, jj, which_triangle: to check intersection with
-* @param[out] distance  
+* @param[out] distance
 */
 double TerrainRadiationComplex::IntersectionRayTriangle(std::vector<double> v_view, size_t mm, size_t nn, size_t ii, size_t jj, size_t which_triangle)
 {
 	std::vector<double> aufpunkt_ray, balance_point_par, intersection;
 	std::vector<double> e_x,e_y,e_xT,e_yT,n;
-	
+
 
 	double cellsize=dem.cellsize;
 	double distance, P_3, r_3;
@@ -839,11 +842,11 @@ double TerrainRadiationComplex::IntersectionRayTriangle(std::vector<double> v_vi
 	if (distance<0) return -999;						// light cannot cross the ground
 
 	intersection=VectorDifference(VectorSum(aufpunkt_ray, VectorStretch(v_view, distance)), balance_point_par);	// [MT eq. 2.26] or better see [MT fig. 2.3]
-	
-	// Now slightl different (less formal) procedure than [MT eq. 2.27-2.30]: 
+
+	// Now slightl different (less formal) procedure than [MT eq. 2.27-2.30]:
 	// Want elementary vector, that is normal to e_x => crossproduct
 	// scalarproduct with [MT eq. 2.27] projects out intersection_x
-	// same for e_y .. 
+	// same for e_y ..
 	e_xT=VectorCrossProduct(n,e_x);
 	e_yT=VectorCrossProduct(n,e_y);
 
@@ -857,13 +860,13 @@ double TerrainRadiationComplex::IntersectionRayTriangle(std::vector<double> v_vi
 
 
 /**
-* @brief returns for given triangle and vector the closest vector of the corresponding rotated basic set. 
+* @brief returns for given triangle and vector the closest vector of the corresponding rotated basic set.
 * 	Described after [MT fig. 2.5] in [MT 2.1.3 View-List]
 * @param[in] vec_in: vector that is searching for closest rotated basic set-vector
 * @param[in] ii, jj, which_triangle: triangle specification
-* @param[out] list_index: Index of vector in Basic Set  
+* @param[out] list_index: Index of vector in Basic Set
 */
-size_t TerrainRadiationComplex::vectorToSPixel(std::vector<double> vec_in, size_t ii_dem, size_t jj_dem, int which_triangle){
+size_t TerrainRadiationComplex::vectorToSPixel(std::vector<double> vec_in, size_t ii_dem, size_t jj_dem, size_t which_triangle){
 
 	double azimuth_flat;
 	double delta, phi_temp=0, phi;
@@ -884,7 +887,7 @@ size_t TerrainRadiationComplex::vectorToSPixel(std::vector<double> vec_in, size_
 	if (vec_horizontal[2]<0){
 		std::cout<<"Vector lower than horizon TerrainRadiationComplex::vectorToSPixel\n";
 		return -999;
-	} 
+	}
 
 	vec_projected_xy={vec_horizontal[0],vec_horizontal[1],0};
 	azimuth_flat=AngleBetween2Vectors(vec_projected_xy,{0,1,0}); 				// [MT eq. 2.43]
@@ -899,7 +902,7 @@ size_t TerrainRadiationComplex::vectorToSPixel(std::vector<double> vec_in, size_
 		if (i!=(M_epsilon-1)){
 			delta=acos(-2/float(M_epsilon)+cos(2*phi_temp))/2-phi_temp;
 			phi_temp+=delta;
-		} 
+		}
 		else phi_temp=Cst::PI/2;
 		if(phi<=phi_temp) n=i;
 		i+=1;
@@ -916,17 +919,35 @@ size_t TerrainRadiationComplex::vectorToSPixel(std::vector<double> vec_in, size_
 * @param[in] ii, jj, which_triangle: triangle specification
 * @param[out] LandViewFactor
 */
-double TerrainRadiationComplex::getLandViewFactor(size_t ii_dem, size_t jj_dem, int which_triangle)
+double TerrainRadiationComplex::getLandViewFactor(size_t ii_dem, size_t jj_dem, size_t which_triangle)
 {
 	return 1.-getSkyViewFactor(ii_dem, jj_dem, which_triangle);
 }
+
+
+
+void TerrainRadiationComplex::initSkyViewFactor()
+{
+  for (size_t which_triangle = 0; which_triangle < 2; ++which_triangle) // Triangles: A=1, B=0  [MT Figure 2.2]
+  {
+    for (size_t ii = 1; ii < dimx-1; ++ii)
+  	{
+  		for (size_t jj = 1; jj < dimy-1; ++jj)
+  		{
+       sky_vf[which_triangle][ii][jj]=computeSkyViewFactor(ii, jj, which_triangle);
+  		}
+  	}
+  }
+  sky_vf_mean=(sky_vf[0]+sky_vf[1])/2;
+}
+
 
 /**
 * @brief returns land-view factor [MT 2.1.5 View Factors]
 * @param[in] ii, jj, which_triangle: triangle specification
 * @param[out] LandViewFactor
 */
-double TerrainRadiationComplex::getSkyViewFactor(size_t ii_dem, size_t jj_dem, int which_triangle)
+double TerrainRadiationComplex::computeSkyViewFactor(size_t ii_dem, size_t jj_dem, size_t which_triangle)
 {
 	double sum=0;
 
@@ -939,6 +960,14 @@ double TerrainRadiationComplex::getSkyViewFactor(size_t ii_dem, size_t jj_dem, i
 	}
 
 	return sum/S;
+}
+
+void TerrainRadiationComplex::getSkyViewFactor(mio::Array2D<double> &o_sky_vf) {
+	o_sky_vf = sky_vf_mean;
+}
+
+double TerrainRadiationComplex::getSkyViewFactor(size_t ii_dem, size_t jj_dem, size_t which_triangle) {
+	return sky_vf[which_triangle][ii_dem][jj_dem];
 }
 
 /**
@@ -1140,7 +1169,7 @@ double TerrainRadiationComplex::AngleBetween2Vectors(std::vector<double> vec1, s
 {
 	double sum=0;
 	double angle=0;
-	double norm1,norm2; 
+	double norm1,norm2;
 	if(vec1.size()!=vec2.size()) return -999;
 
 	for (size_t i = 0; i < vec1.size(); ++i)
@@ -1176,4 +1205,3 @@ void TerrainRadiationComplex::PrintProgress(double percentage)
     fflush (stdout);
 
 }
-

--- a/alpine3d/ebalance/TerrainRadiationComplex.h
+++ b/alpine3d/ebalance/TerrainRadiationComplex.h
@@ -25,6 +25,7 @@
 #include <alpine3d/ebalance/RadiationField.h>
 #include <alpine3d/ebalance/SolarPanel.h>
 #include <alpine3d/ebalance/SnowBRDF.h>
+#include <alpine3d/MPIControl.h>
 
 
 /**

--- a/alpine3d/ebalance/TerrainRadiationComplex.h
+++ b/alpine3d/ebalance/TerrainRadiationComplex.h
@@ -30,24 +30,24 @@
 /**
  * @page TerrainRadiationComplex
 
- * This module calculates the radiative transfer of SW radiation in snow-covered terrain. It can take into account anisotropic reflection 
- * of light on snow (forward scattering) and multiple reflections in the terrain. The price for this complexity is high: 
- * The initialization time is extremely long (for a DEM with 30'000 pixels it can be 12 hours. However, if a ViewList-file is generated 
- * during the initialization, it can be bypassed in later simulations. ) In the main computation loop, the effort is considerable too 
- * and may dominate the simulation time in many cases. Therefore, this module is recommended for explicit radiation investigations based 
- * on relatively small, high-resolution DEM's. It can also be coupled to the SolarPanel-module for precise simulation of radiation on 
- * photovoltaic panels. 
- * The algorithm is described in the master thesis of Felix von Rütte, entitled "Radiative Transfer Model for Snowy Mountains". In the 
- * comments is often referred to by the abbreviation "MT". If you don't find a version online, ask Michael Lehning, he was the supervisor. 
+ * This module calculates the radiative transfer of SW radiation in snow-covered terrain. It can take into account anisotropic reflection
+ * of light on snow (forward scattering) and multiple reflections in the terrain. The price for this complexity is high:
+ * The initialization time is extremely long (for a DEM with 30'000 pixels it can be 12 hours. However, if a ViewList-file is generated
+ * during the initialization, it can be bypassed in later simulations. ) In the main computation loop, the effort is considerable too
+ * and may dominate the simulation time in many cases. Therefore, this module is recommended for explicit radiation investigations based
+ * on relatively small, high-resolution DEM's. It can also be coupled to the SolarPanel-module for precise simulation of radiation on
+ * photovoltaic panels.
+ * The algorithm is described in the master thesis of Felix von Rütte, entitled "Radiative Transfer Model for Snowy Mountains". In the
+ * comments is often referred to by the abbreviation "MT". If you don't find a version online, ask Michael Lehning, he was the supervisor.
  *
  * @keys in io-file
  * COMPLEX_ANISOTROPY [true or false] 		: Whether a snow BRDF should be included. False means isotropic scattering.
- * COMPLEX_MULTIPLE [true or false]			: Whether multiple scattering in the terrain should be taken into account. 
+ * COMPLEX_MULTIPLE [true or false]			: Whether multiple scattering in the terrain should be taken into account.
  * COMPLEX_WRITE_VIEWLIST [true or false]	: Whether the initialization stuff should be written to file. (Make sure you have folder "output")
  * COMPLEX_READ_VIEWLIST [true or false]	: Whether an existing initialization file should be read in; bypassing the initialization.
  * COMPLEX_VIEWLISTFILE [<path>/<filename>]	: Path to the ViewList file if existing. (e.g ../input/surface-grids/ViewList_Totalp_30x30.rad)
  *
- * 
+ *
  *
  * @code
  * [EBalance]
@@ -71,9 +71,10 @@ class TerrainRadiationComplex : public TerrainRadiationAlgorithm {
 		TerrainRadiationComplex(const mio::Config& cfg, const mio::DEMObject &dem_in, const std::string& method, const RadiationField* radfield, SolarPanel* PVobject_in);
 		~TerrainRadiationComplex();
 
-		void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal);
+		void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse,
+                      mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal,
+                      mio::Array2D<double>& view_factor);
 		void setMeteo(const mio::Array2D<double>& albedo, const mio::Array2D<double>& ta, const mio::Array2D<double>& rh,const mio::Array2D<double>& ilwr);
-		
 
 	private:
 
@@ -90,9 +91,12 @@ class TerrainRadiationComplex : public TerrainRadiationAlgorithm {
 		// auxiliary functions
 		std::vector<double> TriangleNormal(size_t ii_dem, size_t jj_dem, int which_triangle);
 		double IntersectionRayTriangle(std::vector<double> ray, size_t ii_0, size_t jj_0, size_t ii_dem, size_t jj_dem, size_t which_triangle);
-		size_t vectorToSPixel(std::vector<double> vec_in, size_t ii_dem, size_t jj_dem, int which_triangle);
-		double getLandViewFactor(size_t ii_dem, size_t jj_dem, int which_triangle);
-		double getSkyViewFactor(size_t ii_dem, size_t jj_dem, int which_triangle);
+		size_t vectorToSPixel(std::vector<double> vec_in, size_t ii_dem, size_t jj_dem, size_t which_triangle);
+		double getLandViewFactor(size_t ii_dem, size_t jj_dem, size_t which_triangle);
+    void initSkyViewFactor();
+    double computeSkyViewFactor(size_t ii_dem, size_t jj_dem, size_t which_triangle);
+		double getSkyViewFactor(size_t ii_dem, size_t jj_dem, size_t which_triangle);
+    void getSkyViewFactor(mio::Array2D<double> &o_sky_vf);
 		std::vector<double> getVectorSun(double solarAzimuth,double solarElevation);
 		double TerrainBiggestDifference(mio::Array3D<double> terrain_old, mio::Array3D<double> terrain_new);
 
@@ -115,13 +119,13 @@ class TerrainRadiationComplex : public TerrainRadiationAlgorithm {
 
 
 		// Variables
-		const size_t dimx, dimy;		
+		const size_t dimx, dimy;
 		mio::DEMObject dem;
 		const mio::Config& cfg;
 
 		SnowBRDF BRDFobject;
 		const RadiationField* radobject;
-		SolarPanel* PVobject;	
+		SolarPanel* PVobject;
 
 		mio::Array3D<std::vector<double> > SortList;				// Used for speedup in Terrain Iterations
 		std::vector< std::vector<double> > BasicSet_Horizontal; 	// Horizontal Basic Set [MT 2.1.1 Basic Set]
@@ -129,7 +133,8 @@ class TerrainRadiationComplex : public TerrainRadiationAlgorithm {
 		mio::Array4D<std::vector<double> > ViewList;				// Stores all information of network between pixels [MT 2.1.3 View List, eq. 2.47]
 		mio::Array2D<double> RList; 								// List pre-storage of BRDF values
 		mio::Array2D<double> albedo_grid;							// Albedo value for each square Pixel
-
+    mio::Array2D<double> sky_vf_mean; // Grid to store view factor
+    std::vector< mio::Array2D<double> > sky_vf;// Array to stor grid of view factor for both values of which_triangle
 		unsigned int M_epsilon;				// Number of small circles in Basic Set [MT fig. 2.1]
 		unsigned int M_phi;					// Number of vectors per small circle of Basic Set [MT fig. 2.1]
 		unsigned int S;						// Number of vectors per Basic Set [MT fig. 2.1]
@@ -137,8 +142,8 @@ class TerrainRadiationComplex : public TerrainRadiationAlgorithm {
 
 		// Keys from io-file
 		bool if_anisotropy=false; 			// Anisotropic or Isotropic Snow Model ?
-		bool if_multiple=false;				// Do Multiple Scattering in Terrain or not ? 
-		bool if_write_view_list=true;		// Write ViewList to file ? 
+		bool if_multiple=false;				// Do Multiple Scattering in Terrain or not ?
+		bool if_write_view_list=true;		// Write ViewList to file ?
 		bool if_read_view_list=false;		// Read existing View-list file? -> Speeds up Initialisation by factor ~200
 };
 

--- a/alpine3d/ebalance/TerrainRadiationHelbig.cc
+++ b/alpine3d/ebalance/TerrainRadiationHelbig.cc
@@ -52,6 +52,17 @@ TerrainRadiationHelbig::TerrainRadiationHelbig(const mio::Config& cfg, const mio
 	lw_sky.resize( dimx, dimy );
 
 	LW_distance_index = (int)ceil(lw_radius / cellsize);
+
+  bool write_sky_vf=false;
+  cfg.getValue("WRITE_SKY_VIEW_FACTOR", "output", write_sky_vf,IOUtils::nothrow);
+
+  if(MPIControl::instance().master() && write_sky_vf){
+    std::cout << "[i] Writing sky view factor grid" << std::endl;
+    mio::Array2D<double> sky_vf(dimx,dimy);
+    getSkyViewFactor(sky_vf);
+    mio::IOManager io(cfg);
+    io.write2DGrid(mio::Grid2DObject(dem_in.cellsize,dem_in.llcorner,sky_vf), "SKY_VIEW_FACTOR");
+  }
 }
 
 void TerrainRadiationHelbig::getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse,

--- a/alpine3d/ebalance/TerrainRadiationHelbig.cc
+++ b/alpine3d/ebalance/TerrainRadiationHelbig.cc
@@ -53,13 +53,20 @@ TerrainRadiationHelbig::TerrainRadiationHelbig(const mio::Config& cfg, const mio
 	LW_distance_index = (int)ceil(lw_radius / cellsize);
 }
 
-void TerrainRadiationHelbig::getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal)
+void TerrainRadiationHelbig::getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse,
+                                          mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal,
+                                          mio::Array2D<double>& view_factor)
 {
 		std::cout << "[i] calc nora radiation" << std::endl;
 		tdir = direct;
 		tdiff = diffuse;
 		Compute();
 		terrain = total_diff;
+    getSkyViewFactor(view_factor);
+}
+
+void TerrainRadiationHelbig::getSkyViewFactor(mio::Array2D<double> &o_sky_vf) {
+	viewFactorsHelbigObj.getSkyViewFactor(o_sky_vf);
 }
 
 void TerrainRadiationHelbig::setMeteo(const mio::Array2D<double> &albedo,const mio::Array2D<double> &ta,const mio::Array2D<double> &rh,const mio::Array2D<double> &ilwr)

--- a/alpine3d/ebalance/TerrainRadiationHelbig.cc
+++ b/alpine3d/ebalance/TerrainRadiationHelbig.cc
@@ -63,6 +63,7 @@ void TerrainRadiationHelbig::getRadiation(const mio::Array2D<double>& direct, mi
 		tdiff = diffuse;
 		Compute();
 		terrain = total_terrain;
+    diffuse=tdiff;
     getSkyViewFactor(view_factor);
 }
 

--- a/alpine3d/ebalance/TerrainRadiationHelbig.cc
+++ b/alpine3d/ebalance/TerrainRadiationHelbig.cc
@@ -62,7 +62,7 @@ void TerrainRadiationHelbig::getRadiation(const mio::Array2D<double>& direct, mi
 		tdir = direct;
 		tdiff = diffuse;
 		Compute();
-		terrain = total_terrain;
+		terrain = total_terrain; //total_terrain;
     diffuse=tdiff;
     getSkyViewFactor(view_factor);
 }
@@ -143,7 +143,7 @@ int TerrainRadiationHelbig::SWTerrainRadiationStep(const double threshold_itEps_
 				sw_t(i,j) += rad;
 				// in addition the received amount is added to the total radiation at ij
 				glob_h(i,j) += rad;
-        total_terrain(i,j) += rad;
+				total_terrain(i,j) += viewFactor * sw_shoot;
 
 				s++;
 			} // end of if only for distances lower than sw_radius

--- a/alpine3d/ebalance/TerrainRadiationHelbig.cc
+++ b/alpine3d/ebalance/TerrainRadiationHelbig.cc
@@ -62,7 +62,7 @@ void TerrainRadiationHelbig::getRadiation(const mio::Array2D<double>& direct, mi
 		tdir = direct;
 		tdiff = diffuse;
 		Compute();
-		terrain = total_terrain; //total_terrain;
+		terrain = total_terrain;
     diffuse=tdiff;
     getSkyViewFactor(view_factor);
 }

--- a/alpine3d/ebalance/TerrainRadiationHelbig.h
+++ b/alpine3d/ebalance/TerrainRadiationHelbig.h
@@ -76,7 +76,8 @@ class TerrainRadiationHelbig: public TerrainRadiationAlgorithm {
 	public:
 		TerrainRadiationHelbig(const mio::Config& i_cfg, const mio::DEMObject& dem_in, const int& i_nbworkers, const std::string& method);
 
-		void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal);
+		void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain,
+                      mio::Array2D<double>& direct_unshaded_horizontal, mio::Array2D<double>& view_factor);
 		void setMeteo(const mio::Array2D<double>& albedo, const mio::Array2D<double>& ta,
 		              const mio::Array2D<double>& rh, const mio::Array2D<double>& ilwr);
 
@@ -132,6 +133,7 @@ class TerrainRadiationHelbig: public TerrainRadiationAlgorithm {
 		void fillSWResultsGrids(const bool& day);
 
 		void InitializeLW (const int i, const int j);
+    void getSkyViewFactor(mio::Array2D<double> &o_sky_vf);
 
 		static inline void CalculateIndex(const int indice, const int distance_max, int dim, int * min, int * max);
 		static inline void LWTerrainRadiationCore(const double bx2, const int j_shoot, const double z_shoot, const int j, const double z, const double cellsize, const double t_snow_shoot,const double t_snow_shoot_value ,const double t_a, const double vf, double * lwi, int * s);

--- a/alpine3d/ebalance/TerrainRadiationHelbig.h
+++ b/alpine3d/ebalance/TerrainRadiationHelbig.h
@@ -19,6 +19,7 @@
 #define TERRAINRADIATIONHELBIG_H
 
 #include <meteoio/MeteoIO.h>
+#include <alpine3d/MPIControl.h>
 #include <alpine3d/ebalance/TerrainRadiationAlgorithm.h>
 #include <alpine3d/ebalance/VFSymetricMatrix.h>
 #include <alpine3d/ebalance/ViewFactorsHelbig.h>

--- a/alpine3d/ebalance/TerrainRadiationHelbig.h
+++ b/alpine3d/ebalance/TerrainRadiationHelbig.h
@@ -105,7 +105,7 @@ class TerrainRadiationHelbig: public TerrainRadiationAlgorithm {
 		double itEps_LW;
 		double max_alb;              // max ground albedo
 
-		mio::Array2D<double> total_diff, tdir, tdiff, sw_t, glob_start, glob_h_isovf, glob_h, t_snowold;
+		mio::Array2D<double> total_diff, tdir, tdiff, sw_t, glob_start, glob_h_isovf, glob_h, t_snowold, total_terrain;
 		//SnowpackInterface *snowpack;
 
 		double lw_start_l1;
@@ -123,13 +123,13 @@ class TerrainRadiationHelbig: public TerrainRadiationAlgorithm {
 		std::vector<CellsList> lwt_byCell;
 
 		void Compute();
-		int SWTerrainRadiationStep(const double threshold_itEps_SW, int *c, int *d, unsigned int n, const clock_t t0);
+		int SWTerrainRadiationStep(const double threshold_itEps_SW, int &c, int &d, unsigned int n, const clock_t t0);
 		int LWTerrainRadiationStep(const double threshold_itEps_LW, const int itMax_LW, const int i_shoot, const int j_shoot, unsigned int n, const clock_t t0);
-		int ComputeTerrainRadiation(const bool& day, int c, int d);
+		void ComputeTerrainRadiation(const bool& day, int i_max_unshoot, int j_max_unshoot );
 		void ComputeRadiationBalance();
-		void InitializeTerrainSwSplitting(const int& i, const int& j,
-		                                  int *i_max_unshoot, int *j_max_unshoot, double *diffmax_sw);
-		void InitializeTerrainRadiation(const bool& day, int *c, int *d);
+		void InitializeTerrainSwSplitting(const int i, const int j,
+		                                  int& i_max_unshoot, int& j_max_unshoot, double& diffmax_sw);
+		void InitializeTerrainRadiation(const bool& day, int& i_max_unshoot, int& j_max_unshoot);
 		void fillSWResultsGrids(const bool& day);
 
 		void InitializeLW (const int i, const int j);

--- a/alpine3d/ebalance/TerrainRadiationPETSc.cc
+++ b/alpine3d/ebalance/TerrainRadiationPETSc.cc
@@ -115,7 +115,7 @@ TerrainRadiationPETSc::~TerrainRadiationPETSc()
 }
 
 
-void TerrainRadiationPETSc::getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal)
+void TerrainRadiationPETSc::getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal, mio::Array2D<double>& view_factor)
 {
 	Array2D<double> Qin_raw(dimx,dimy,0);
 	Qin_raw += diffuse;

--- a/alpine3d/ebalance/TerrainRadiationPETSc.h
+++ b/alpine3d/ebalance/TerrainRadiationPETSc.h
@@ -32,7 +32,7 @@ class TerrainRadiationPETSc : public TerrainRadiationAlgorithm {
 		TerrainRadiationPETSc(const mio::Config& i_cfg, const mio::DEMObject& dem_in, const int& i_nbworkers, const std::string& method);
 		~TerrainRadiationPETSc();
 
-		void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal);
+		void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal, mio::Array2D<double>& view_factor);
 		void setMeteo(const mio::Array2D<double>& albedo, const mio::Array2D<double>& ta,
 		              const mio::Array2D<double>& rh, const mio::Array2D<double>& ilwr);
 

--- a/alpine3d/ebalance/TerrainRadiationSimple.cc
+++ b/alpine3d/ebalance/TerrainRadiationSimple.cc
@@ -20,7 +20,7 @@
 
 using namespace mio;
 
-TerrainRadiationSimple::TerrainRadiationSimple(const mio::DEMObject& dem_in, const std::string& method)
+TerrainRadiationSimple::TerrainRadiationSimple(const mio::Config& i_cfg, const mio::DEMObject& dem_in, const std::string& method)
 					  : TerrainRadiationAlgorithm(method),
 						albedo_grid(dem_in.getNx(), dem_in.getNy(), IOUtils::nodata), sky_vf(dem_in.getNx(), dem_in.getNy(), IOUtils::nodata),
 						dimx(dem_in.getNx()), dimy(dem_in.getNy()), startx(0), endx(dimx)
@@ -31,6 +31,16 @@ TerrainRadiationSimple::TerrainRadiationSimple(const mio::DEMObject& dem_in, con
 	endx = startx + nx;
 
 	initSkyViewFactor(dem_in);
+
+  bool write_sky_vf=false;
+  i_cfg.getValue("WRITE_SKY_VIEW_FACTOR", "output", write_sky_vf,IOUtils::nothrow);
+
+  if(MPIControl::instance().master() && write_sky_vf){
+    std::cout << "[i] Writing sky view factor grid" << std::endl;
+    mio::IOManager io(i_cfg);
+    io.write2DGrid(mio::Grid2DObject(dem_in.cellsize,dem_in.llcorner,sky_vf), "SKY_VIEW_FACTOR");
+  }
+
 }
 
 TerrainRadiationSimple::~TerrainRadiationSimple() {}

--- a/alpine3d/ebalance/TerrainRadiationSimple.h
+++ b/alpine3d/ebalance/TerrainRadiationSimple.h
@@ -37,7 +37,7 @@
 class TerrainRadiationSimple : public TerrainRadiationAlgorithm {
 
 	public:
-		TerrainRadiationSimple(const mio::DEMObject &dem_in, const std::string& method);
+		TerrainRadiationSimple(const mio::Config& i_cfg, const mio::DEMObject &dem_in, const std::string& method);
 		~TerrainRadiationSimple();
 
 		void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain,

--- a/alpine3d/ebalance/TerrainRadiationSimple.h
+++ b/alpine3d/ebalance/TerrainRadiationSimple.h
@@ -40,13 +40,14 @@ class TerrainRadiationSimple : public TerrainRadiationAlgorithm {
 		TerrainRadiationSimple(const mio::DEMObject &dem_in, const std::string& method);
 		~TerrainRadiationSimple();
 
-		void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain, mio::Array2D<double>& direct_unshaded_horizontal);
+		void getRadiation(const mio::Array2D<double>& direct, mio::Array2D<double>& diffuse, mio::Array2D<double>& terrain,
+                      mio::Array2D<double>& direct_unshaded_horizontal,mio::Array2D<double>& view_factor);
 		void setMeteo(const mio::Array2D<double>& albedo, const mio::Array2D<double>& ta, const mio::Array2D<double>& rh,const mio::Array2D<double>& ilwr);
-		void getSkyViewFactor(mio::Array2D<double> &o_sky_vf) const;
 
 	private:
 		double getAlbedo(const size_t& ii, const size_t& jj);
-		void initSkyViewFactors(const mio::DEMObject &dem);
+		void initSkyViewFactor(const mio::DEMObject &dem);
+    void getSkyViewFactor(mio::Array2D<double> &o_sky_vf);
 
 		mio::Array2D<double> albedo_grid, sky_vf;
 


### PR DESCRIPTION
Added many new output grids, the keys are:

WRITE_SKY_VIEW_FACTOR = true
WRITE_DEM_DETAILS = true
GRIDS_PARAMETERS =  ISWR_TERRAIN ILWR_TERRAIN ISWR_BELOW_CAN

ILWR_TERRAIN is not yet implemented yet. ISWR_DIFF and ISWR_DIR are now above canopy, with the new key ISWR_BELOW_CAN to get below canopy radiation (the information about splitting is lost at this stage). Some correction has been made to the HELBIFB EB module. Finally, a new static vector grids_not_computed_in_worker in present in SnowpackInterface.cc in order to not fill some unused grids in SnowpackInterfaceWorker.
